### PR TITLE
Default marker type change

### DIFF
--- a/lib/minimap-linter-config.js
+++ b/lib/minimap-linter-config.js
@@ -3,7 +3,7 @@
 export default {
   markerType: {
     type: 'string',
-    default: 'highlight-over',
+    default: 'line',
     enum: ['line', 'highlight-under', 'highlight-over', 'highlight-outline'],
     description: 'Marker type'
   }


### PR DESCRIPTION
Changed default marker type to *line*. Should avoid issues like https://github.com/AtomLinter/atom-minimap-linter/issues/4