### PR TITLE
Defer package dependency checks

### DIFF
--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -9,11 +9,22 @@ const bindings = new Map();
 export default {
   // Atom package lifecycle events start
   activate() {
-    require('atom-package-deps').install('minimap-linter');
+    this.idleCallbacks = new Set();
+    let depsCallbackID;
+    const installMinimapLinterDeps = () => {
+      this.idleCallbacks.delete(depsCallbackID);
+      if (!atom.inSpecMode()) {
+        require('atom-package-deps').install('minimap-linter');
+      }
+    };
+    depsCallbackID = window.requestIdleCallback(installMinimapLinterDeps);
+    this.idleCallbacks.add(depsCallbackID);
     this.subscriptions = new CompositeDisposable();
   },
 
   deactivate() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    this.idleCallbacks.clear();
     if (!this.minimapProvider) {
       return;
     }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
       "atom": true
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   }
 }


### PR DESCRIPTION
Defer the checking for dependent package installation till Atom determines it is "idle", there is no reason this needs to happen immediately on package activation.