### PR TITLE
Handle multiple TextEditor for the same content

### DIFF
--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -11,21 +11,64 @@ const goodMessage = (message, filePath) =>
   (messagePath(message) === filePath && messageRange(message));
 
 export default class MinimapLinterBinding {
-  constructor(minimap) {
+  constructor(minimap, messages) {
     this.minimap = minimap;
+    this.messages = messages;
     this.subscriptions = new CompositeDisposable();
     this.editor = this.minimap.getTextEditor();
     this.markerLayer = this.editor.addMarkerLayer();
 
-    this.messages = new Set();
     this.markers = new Map();
     this.decorations = new Set();
+    this.idleCallbacks = new Set();
 
     this.subscriptions.add(atom.config.observe('minimap-linter.markerType', (value) => {
       this.markerType = value;
       this.removeDecorations();
       this.markers.forEach((marker, message) => this.decorateMarker(marker, message));
     }));
+
+    // Handle any existing messages in the cache for this file
+    let hasMessages = false;
+    const filePath = this.editor.getPath();
+    this.messages.forEach((message) => {
+      if (!hasMessages && goodMessage(message, filePath)) {
+        hasMessages = true;
+        this.renderOldMessages();
+      }
+    });
+  }
+
+  async waitOnIdle() {
+    return new Promise((resolve) => {
+      const callbackID = window.requestIdleCallback(() => {
+        this.idleCallbacks.delete(callbackID);
+        resolve();
+      });
+      this.idleCallbacks.add(callbackID);
+    });
+  }
+
+  async renderOldMessages() {
+    // FIXME: Wait on an idle timeout as if we process this immediately the
+    // TextEditor isn't ready yet.
+    // Needs to be fixed in Minimap as it is the one calling this package too early
+    await this.waitOnIdle();
+    const filePath = this.editor.getPath(); // Not cached as it may change
+    if (filePath) {
+      this.messages.forEach((message) => {
+        if (goodMessage(message, filePath)) {
+          this.addMessage(message);
+        }
+      });
+    }
+  }
+
+  addMessage(message) {
+    const markerRange = messageRange(message);
+    const marker = this.markerLayer.markBufferRange(markerRange, { invalidate: 'never' });
+    this.markers.set(message, marker);
+    this.decorateMarker(marker, message);
   }
 
   renderDecorations(messagePatch) {
@@ -56,11 +99,8 @@ export default class MinimapLinterBinding {
 
     // Handle any added messages
     added.forEach((message) => {
-      const markerRange = messageRange(message);
-      const marker = this.markerLayer.markBufferRange(markerRange, { invalidate: 'never' });
-      this.markers.set(message, marker);
       this.messages.add(message);
-      this.decorateMarker(marker, message);
+      this.addMessage(message);
     });
   }
 
@@ -82,7 +122,6 @@ export default class MinimapLinterBinding {
     this.removeDecorations();
     this.markers.forEach(marker => marker.destroy());
     this.markers.clear();
-    this.messages.clear();
   }
 
   destroy() {
@@ -90,5 +129,4 @@ export default class MinimapLinterBinding {
     this.markerLayer.destroy();
     this.subscriptions.dispose();
   }
-
 }

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -3,17 +3,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable } from 'atom';
 
-const messagePath = message =>
-  (message.version === 1 ? message.filePath : message.location.file);
 const messageRange = message =>
   (message.version === 1 ? message.range : message.location.position);
-const goodMessage = (message, filePath) =>
-  (messagePath(message) === filePath && messageRange(message));
 
 export default class MinimapLinterBinding {
-  constructor(minimap, messages) {
+  constructor(minimap) {
     this.minimap = minimap;
-    this.messages = messages;
     this.subscriptions = new CompositeDisposable();
     this.editor = this.minimap.getTextEditor();
     this.markerLayer = this.editor.addMarkerLayer();
@@ -27,41 +22,10 @@ export default class MinimapLinterBinding {
       this.removeDecorations();
       this.markers.forEach((marker, message) => this.decorateMarker(marker, message));
     }));
-
-    // Handle any existing messages in the cache for this file
-    let hasMessages = false;
-    const filePath = this.editor.getPath();
-    this.messages.forEach((message) => {
-      if (!hasMessages && goodMessage(message, filePath)) {
-        hasMessages = true;
-        this.renderOldMessages();
-      }
-    });
   }
 
-  async waitOnIdle() {
-    return new Promise((resolve) => {
-      const callbackID = window.requestIdleCallback(() => {
-        this.idleCallbacks.delete(callbackID);
-        resolve();
-      });
-      this.idleCallbacks.add(callbackID);
-    });
-  }
-
-  async renderOldMessages() {
-    // FIXME: Wait on an idle timeout as if we process this immediately the
-    // TextEditor isn't ready yet.
-    // Needs to be fixed in Minimap as it is the one calling this package too early
-    await this.waitOnIdle();
-    const filePath = this.editor.getPath(); // Not cached as it may change
-    if (filePath) {
-      this.messages.forEach((message) => {
-        if (goodMessage(message, filePath)) {
-          this.addMessage(message);
-        }
-      });
-    }
+  hasMessage(message) {
+    return this.markers.has(message);
   }
 
   addMessage(message) {
@@ -71,45 +35,12 @@ export default class MinimapLinterBinding {
     this.decorateMarker(marker, message);
   }
 
-  renderDecorations(messagePatch) {
-    // Parse out what messages have been added/removed
-    const added = new Set();
-    const removed = new Set();
-    const filePath = this.editor.getPath();
-    messagePatch.added.forEach((message) => {
-      if (goodMessage(message, filePath)) {
-        added.add(message);
-      }
-    });
-    messagePatch.removed.forEach((message) => {
-      if (this.messages.has(message)) {
-        removed.add(message);
-      }
-    });
-
-    // Handle any removed messages
-    removed.forEach((message) => {
-      const marker = this.markers.get(message);
-      if (marker) {
-        marker.destroy();
-      }
-      this.messages.delete(message);
-      this.markers.delete(message);
-    });
-
-    // Handle messages removed in a different binding
-    this.markers.forEach((marker, message) => {
-      if (!this.messages.has(message)) {
-        marker.destroy();
-        this.markers.delete(message);
-      }
-    });
-
-    // Handle any added messages
-    added.forEach((message) => {
-      this.messages.add(message);
-      this.addMessage(message);
-    });
+  removeMessage(message) {
+    const marker = this.markers.get(message);
+    if (marker) {
+      marker.destroy();
+    }
+    this.markers.delete(message);
   }
 
   decorateMarker(marker, message) {

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -97,6 +97,14 @@ export default class MinimapLinterBinding {
       this.markers.delete(message);
     });
 
+    // Handle messages removed in a different binding
+    this.markers.forEach((marker, message) => {
+      if (!this.messages.has(message)) {
+        marker.destroy();
+        this.markers.delete(message);
+      }
+    });
+
     // Handle any added messages
     added.forEach((message) => {
       this.messages.add(message);

--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -19,7 +19,9 @@ export default {
     };
     depsCallbackID = window.requestIdleCallback(installMinimapLinterDeps);
     this.idleCallbacks.add(depsCallbackID);
+
     this.subscriptions = new CompositeDisposable();
+    this.messageCache = new Set();
   },
 
   deactivate() {
@@ -30,6 +32,7 @@ export default {
     }
     this.minimapProvider.unregisterPlugin('linter');
     this.minimapProvider = null;
+    this.messageCache.clear();
   },
   // Atom package lifecycle events end
 
@@ -72,7 +75,7 @@ export default {
 
     // Handle each minimap
     this.minimapsSubscription = this.minimapProvider.observeMinimaps((minimap) => {
-      const binding = new MinimapLinterBinding(minimap);
+      const binding = new MinimapLinterBinding(minimap, this.messageCache);
       bindings.set(minimap, binding);
       const subscription = minimap.onDidDestroy(() => {
         binding.destroy();

--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -4,11 +4,17 @@
 import { CompositeDisposable } from 'atom';
 import MinimapLinterBinding from './minimap-linter-binding';
 
-const bindings = new Map();
+const messagePath = message =>
+  (message.version === 1 ? message.filePath : message.location.file);
+const messageRange = message =>
+  (message.version === 1 ? message.range : message.location.position);
+const goodMessage = (message, filePath) =>
+  (messagePath(message) === filePath && messageRange(message));
 
 export default {
   // Atom package lifecycle events start
   activate() {
+    this.bindings = new Map();
     this.idleCallbacks = new Set();
     let depsCallbackID;
     const installMinimapLinterDeps = () => {
@@ -45,15 +51,36 @@ export default {
 
   // LinterUI (for messages)
   provideUI() {
+    const minimapBindings = this.bindings;
+    const messageCache = this.messageCache;
     return {
       name: 'minimap-linter',
       render(messagePatch) {
-        bindings.forEach(binding => binding.renderDecorations(messagePatch));
+        // Parse out what messages have been added/removed
+        const added = new Set();
+        const removed = new Set();
+        minimapBindings.forEach((binding, minimap) => {
+          const filePath = minimap.getTextEditor().getPath();
+          messagePatch.added.forEach((message) => {
+            if (goodMessage(message, filePath)) {
+              added.add(message);
+              binding.addMessage(message);
+            }
+          });
+          messagePatch.removed.forEach((message) => {
+            removed.add(message);
+            if (binding.hasMessage(message)) {
+              binding.removeMessage(message);
+            }
+          });
+        });
+        added.forEach(message => messageCache.add(message));
+        removed.forEach(message => messageCache.delete(message));
       },
       didBeginLinting() {},
       didFinishLinting() {},
       dispose() {
-        bindings.forEach(binding => binding.removeMessages());
+        minimapBindings.forEach(binding => binding.removeMessages());
       },
     };
   },
@@ -75,16 +102,29 @@ export default {
 
     // Handle each minimap
     this.minimapsSubscription = this.minimapProvider.observeMinimaps((minimap) => {
-      const binding = new MinimapLinterBinding(minimap, this.messageCache);
-      bindings.set(minimap, binding);
+      const binding = new MinimapLinterBinding(minimap);
+      this.bindings.set(minimap, binding);
       const subscription = minimap.onDidDestroy(() => {
         binding.destroy();
         this.subscriptions.remove(subscription);
         subscription.dispose();
-        bindings.delete(minimap);
+        this.bindings.delete(minimap);
       });
-
       this.subscriptions.add(subscription);
+
+      // Force rendering of old messages after a small delay
+      let oldMsgCallbackID;
+      const renderOldMessages = () => {
+        this.idleCallbacks.delete(oldMsgCallbackID);
+        const filePath = minimap.getTextEditor().getPath();
+        this.messageCache.forEach((message) => {
+          if (goodMessage(message, filePath)) {
+            binding.addMessage(message);
+          }
+        });
+      };
+      oldMsgCallbackID = window.requestIdleCallback(renderOldMessages);
+      this.idleCallbacks.add(oldMsgCallbackID);
     });
   },
 
@@ -92,9 +132,9 @@ export default {
     if (!this.active) {
       return;
     }
-    bindings.forEach((binding, minimap) => {
+    this.bindings.forEach((binding, minimap) => {
       binding.destroy();
-      bindings.delete(minimap);
+      this.bindings.delete(minimap);
     });
     this.minimapsSubscription.dispose();
     this.subscriptions.dispose();


### PR DESCRIPTION
Make the message cache global to the entire package. When a new `TextEditor` Minimap is registered check whether there are any existing messages in the cache for it, if any were found mark them in this new instance.

Note that currently Minimap triggers this before the TextEditor is actually visible, leading to many cascading bugs. Defer the marking of these old messages to an idle callback to give the TextEditor time to initialize. This needs to be fixed in Minimap itself to generalize this to all plugins.

Moves message handling to the main package out of the bindings. Those are now focused on managing the markers for their specific `TextEditor`.

Fixes #16.