### PR TITLE
Guard against missing TextEditor

### DIFF
--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -60,7 +60,11 @@ export default {
         const added = new Set();
         const removed = new Set();
         minimapBindings.forEach((binding, minimap) => {
-          const filePath = minimap.getTextEditor().getPath();
+          const textEditor = minimap.getTextEditor();
+          if (!atom.workspace.isTextEditor(textEditor)) {
+            return;
+          }
+          const filePath = textEditor.getPath();
           messagePatch.added.forEach((message) => {
             if (goodMessage(message, filePath)) {
               added.add(message);
@@ -116,7 +120,11 @@ export default {
       let oldMsgCallbackID;
       const renderOldMessages = () => {
         this.idleCallbacks.delete(oldMsgCallbackID);
-        const filePath = minimap.getTextEditor().getPath();
+        const textEditor = minimap.getTextEditor();
+        if (!atom.workspace.isTextEditor(textEditor)) {
+          return;
+        }
+        const filePath = textEditor.getPath();
         this.messageCache.forEach((message) => {
           if (goodMessage(message, filePath)) {
             binding.addMessage(message);


### PR DESCRIPTION
Apparently minimap can get into a situation where the `TextEditor` associated with it is no longer valid. Add a guard against this case.

Fixes #19.