### PR TITLE
Add support for diagnostics-store

### DIFF
--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -45,6 +45,10 @@ export default class MinimapLinterBinding {
   }
 
   addMessage(message) {
+    if (this.markers.has(message)) {
+      // This message already has a marker, ignore the duplicate request to mark
+      return;
+    }
     const markerRange = messageRange(message);
     const marker = this.markerLayer.markBufferRange(markerRange, { invalidate: 'never' });
     this.markers.set(message, marker);
@@ -56,6 +60,12 @@ export default class MinimapLinterBinding {
     if (marker) {
       marker.destroy();
     }
+    // Delete references to destroyed decorations
+    this.decorations.forEach((decoration) => {
+      if (decoration.destroyed) {
+        this.decorations.delete(decoration);
+      }
+    });
     this.markers.delete(message);
   }
 

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -4,7 +4,19 @@
 import { CompositeDisposable } from 'atom';
 
 const messageRange = message =>
-  (message.version === 1 ? message.range : message.location.position);
+  (message.range ? message.range : message.location.position);
+const messageSeverity = (message) => {
+  const type = message.type ? message.type.toLowerCase() : '';
+  const severity = message.severity ? message.severity : type;
+  switch (severity) {
+    case 'error':
+    case 'warning':
+    case 'info':
+      return severity;
+    default:
+      return 'error';
+  }
+};
 
 export default class MinimapLinterBinding {
   constructor(minimap) {
@@ -22,6 +34,10 @@ export default class MinimapLinterBinding {
       this.removeDecorations();
       this.markers.forEach((marker, message) => this.decorateMarker(marker, message));
     }));
+  }
+
+  getMessages() {
+    return Array.from(this.markers.keys());
   }
 
   hasMessage(message) {
@@ -44,9 +60,10 @@ export default class MinimapLinterBinding {
   }
 
   decorateMarker(marker, message) {
+    const severity = messageSeverity(message);
     const minimapMarkerDecoration = this.minimap.decorateMarker(marker, {
       type: this.markerType,
-      class: `.linter-${message.severity}`,
+      class: `.linter-${severity}`,
       plugin: 'linter',
     });
     this.decorations.add(minimapMarkerDecoration);

--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -190,7 +190,7 @@ export default {
         }
         const filePath = textEditor.getPath();
         this.messageCache.forEach((message) => {
-          if (goodMessage(message, filePath)) {
+          if (goodMessage(message, filePath) && !binding.hasMessage(message)) {
             binding.addMessage(message);
           }
         });

--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -27,12 +27,14 @@ export default {
     this.idleCallbacks.add(depsCallbackID);
 
     this.subscriptions = new CompositeDisposable();
+    this.minimapSubscriptions = new CompositeDisposable();
     this.messageCache = new Set();
   },
 
   deactivate() {
     this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
     this.idleCallbacks.clear();
+    this.subscriptions.dispose();
     if (!this.minimapProvider) {
       return;
     }
@@ -172,11 +174,11 @@ export default {
       this.bindings.set(minimap, binding);
       const subscription = minimap.onDidDestroy(() => {
         binding.destroy();
-        this.subscriptions.remove(subscription);
+        this.minimapSubscriptions.remove(subscription);
         subscription.dispose();
         this.bindings.delete(minimap);
       });
-      this.subscriptions.add(subscription);
+      this.minimapSubscriptions.add(subscription);
 
       // Force rendering of old messages after a small delay
       let oldMsgCallbackID;
@@ -196,6 +198,7 @@ export default {
       oldMsgCallbackID = window.requestIdleCallback(renderOldMessages);
       this.idleCallbacks.add(oldMsgCallbackID);
     });
+    this.minimapSubscriptions.add(this.minimapsSubscription);
   },
 
   deactivatePlugin() {
@@ -206,8 +209,7 @@ export default {
       binding.destroy();
       this.bindings.delete(minimap);
     });
-    this.minimapsSubscription.dispose();
-    this.subscriptions.dispose();
+    this.minimapSubscriptions.dispose();
   },
   // Minimap plugin lifecycle events end
 };

--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -5,9 +5,9 @@ import { CompositeDisposable } from 'atom';
 import MinimapLinterBinding from './minimap-linter-binding';
 
 const messagePath = message =>
-  (message.version === 1 ? message.filePath : message.location.file);
+  (message.filePath ? message.filePath : message.location.file);
 const messageRange = message =>
-  (message.version === 1 ? message.range : message.location.position);
+  (message.range ? message.range : message.location.position);
 const goodMessage = (message, filePath) =>
   (messagePath(message) === filePath && messageRange(message));
 
@@ -103,6 +103,52 @@ export default {
         minimapBindings.forEach(binding => binding.removeMessages());
       },
     };
+  },
+
+  // atom-ide-ui / Nuclide messages
+  consumeDiagnosticUpdates(diagnosticUpdater) {
+    const updateMessageCache = this.updateMessageCache.bind(this);
+
+    this.subscriptions.add(diagnosticUpdater.observeMessages((messages) => {
+      const added = new Set();
+      const removed = new Set();
+      this.bindings.forEach((binding, minimap) => {
+        // Validate the editor
+        const textEditor = minimap.getTextEditor();
+        if (!atom.workspace.isTextEditor(textEditor)) {
+          return;
+        }
+        const filePath = textEditor.getPath();
+        if (!filePath) {
+          return;
+        }
+
+        // Filter the message list for the current binding's TextEditor
+        const filteredMessages = messages.filter((message) => {
+          if (message.scope !== 'file' || message.filePath == null) {
+            return false;
+          }
+          return goodMessage(message, filePath);
+        });
+
+        // Remove any messages not in the given list
+        binding.getMessages().forEach((message) => {
+          if (!filteredMessages.includes(message)) {
+            removed.add(message);
+          }
+        });
+
+        // Add any new messages
+        filteredMessages.forEach((message) => {
+          if (!binding.hasMessage(message)) {
+            added.add(message);
+            binding.addMessage(message);
+          }
+        });
+      });
+
+      updateMessageCache(added, removed);
+    }));
   },
   // Package dependencies provisioning end
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
       "versions": {
         "1.0.0": "consumeMinimapServiceV1"
       }
+    },
+    "diagnostics-store": {
+      "versions": {
+        "0.3.0": "consumeDiagnosticUpdates"
+      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
Add support for the `diagnostics-store` service used by `atom-ide-ui` (as well as `nuclide`?) so that messages still work when using that consumer of Linter providers.

@hansonw Is there a better way to consume these messages?