### PR TITLE
Remove messages from all bindings

### DIFF
--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -43,6 +43,19 @@ export default {
   // Atom package lifecycle events end
 
   // Package dependencies provisioning start
+  // Message management
+  updateMessageCache(added, removed) {
+    added.forEach(message => this.messageCache.add(message));
+    removed.forEach((message) => {
+      this.bindings.forEach((binding) => {
+        if (binding.hasMessage(message)) {
+          binding.removeMessage(message);
+        }
+      });
+      this.messageCache.delete(message);
+    });
+  },
+
   // Minimap
   consumeMinimapServiceV1(minimap) {
     this.minimapProvider = minimap;
@@ -51,34 +64,38 @@ export default {
 
   // LinterUI (for messages)
   provideUI() {
-    const { bindings: minimapBindings, messageCache } = this;
+    const updateMessageCache = this.updateMessageCache.bind(this);
+    const { bindings: minimapBindings } = this;
+
     return {
       name: 'minimap-linter',
       render(messagePatch) {
         // Parse out what messages have been added/removed
         const added = new Set();
-        const removed = new Set();
+        // Store the removed messages for later batched removal
+        const removed = new Set(messagePatch.removed);
+
         minimapBindings.forEach((binding, minimap) => {
+          // Validate the editor
           const textEditor = minimap.getTextEditor();
           if (!atom.workspace.isTextEditor(textEditor)) {
             return;
           }
           const filePath = textEditor.getPath();
+          if (!filePath) {
+            return;
+          }
+
+          // Add the messages specific to this TextEditor
           messagePatch.added.forEach((message) => {
             if (goodMessage(message, filePath)) {
               added.add(message);
               binding.addMessage(message);
             }
           });
-          messagePatch.removed.forEach((message) => {
-            removed.add(message);
-            if (binding.hasMessage(message)) {
-              binding.removeMessage(message);
-            }
-          });
         });
-        added.forEach(message => messageCache.add(message));
-        removed.forEach(message => messageCache.delete(message));
+
+        updateMessageCache(added, removed);
       },
       didBeginLinting() {},
       didFinishLinting() {},


### PR DESCRIPTION
Properly queue up messages for removal, and then remove from all bindings at once. Before this it was possible for a message to be removed from one binding and then get "stuck" in other bindings as it was already marked as removed.

Before this you could get a message "stuck" by:
1. Open a file
2. Trigger a message on the file
3. Split the file so there are two instances open for it
4. Trigger a second, new, message in the file
5. Fix both messages
6. Note that the initial message is still showing for the second view on the file