### PR TITLE
Better checking of diagnostic messages

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,64 @@
+'use babel';
+
+/**
+ * Given a message, return the associated path, or null if there isn't one
+ * @param  {Object} message The message to parse
+ * @return {String}         The associated path, or null
+ */
+export const messagePath = (message) => {
+  if (message.filePath) {
+    return message.filePath;
+  }
+  if (message.location && message.location.file) {
+    return message.location.file;
+  }
+  return null;
+};
+
+/**
+ * Given a message, return the associated range, or null if there isn't one
+ * @param  {Object} message The message to parse
+ * @return {any}         The associated range, or null
+ */
+export const messageRange = (message) => {
+  if (message.range) {
+    return message.range;
+  }
+  if (message.location && message.location.position) {
+    return message.location.position;
+  }
+  return null;
+};
+
+/**
+ * Given a message, return the associated severity, defaulting to error
+ * @param  {Object} message The message to parse
+ * @return {string}         The message severity
+ */
+export const messageSeverity = (message) => {
+  const type = message.type ? message.type.toLowerCase() : '';
+  const severity = message.severity ? message.severity : type;
+  switch (severity) {
+    case 'error':
+    case 'warning':
+    case 'info':
+      return severity;
+    default:
+      return 'error';
+  }
+};
+
+/**
+ * Check whether a message is related to the given path
+ * @param  {Object} message The message to check
+ * @param  {string} filePath Path to check the message against
+ * @return {boolean}          Whether the message belongs to that path or not
+ */
+export const goodMessage = (message, filePath) => {
+  if (messagePath(message) === filePath) {
+    if (messageRange(message)) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -2,21 +2,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable } from 'atom';
-
-const messageRange = message =>
-  (message.range ? message.range : message.location.position);
-const messageSeverity = (message) => {
-  const type = message.type ? message.type.toLowerCase() : '';
-  const severity = message.severity ? message.severity : type;
-  switch (severity) {
-    case 'error':
-    case 'warning':
-    case 'info':
-      return severity;
-    default:
-      return 'error';
-  }
-};
+import { messageRange, messageSeverity } from './helpers';
 
 export default class MinimapLinterBinding {
   constructor(minimap) {

--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -3,13 +3,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable } from 'atom';
 import MinimapLinterBinding from './minimap-linter-binding';
-
-const messagePath = message =>
-  (message.filePath ? message.filePath : message.location.file);
-const messageRange = message =>
-  (message.range ? message.range : message.location.position);
-const goodMessage = (message, filePath) =>
-  (messagePath(message) === filePath && messageRange(message));
+import { goodMessage } from './helpers';
 
 export default {
   // Atom package lifecycle events start

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -1,0 +1,134 @@
+'use babel';
+
+import * as helpers from '../lib/helpers';
+
+describe('The helpers module', () => {
+  describe('messagePath', () => {
+    it('works with v1 and diagnostics-store messages', () => {
+      const message = { filePath: 'foo' };
+      const parsed = helpers.messagePath(message);
+      expect(parsed).toBe(message.filePath);
+    });
+
+    it('works with v2 messages', () => {
+      const message = { location: { file: 'foo' } };
+      const parsed = helpers.messagePath(message);
+      expect(parsed).toBe(message.location.file);
+    });
+
+    it('handles invalid v2 messages', () => {
+      const message = { location: {} };
+      const parsed = helpers.messagePath(message);
+      expect(parsed).toBe(null);
+    });
+
+    it('handles invalid v1/diagnostics-store messages', () => {
+      const message = {};
+      const parsed = helpers.messagePath(message);
+      expect(parsed).toBe(null);
+    });
+  });
+
+  describe('messageRange', () => {
+    it('works with v1 and diagnostics-store messages', () => {
+      const message = { range: [[0, 0], [0, 1]] };
+      const parsed = helpers.messageRange(message);
+      expect(parsed).toBe(message.range);
+    });
+
+    it('works with v2 messages', () => {
+      const message = { location: { position: [[0, 0], [0, 1]] } };
+      const parsed = helpers.messageRange(message);
+      expect(parsed).toBe(message.location.position);
+    });
+
+    it('handles invalid v2 messages', () => {
+      const message = { location: {} };
+      const parsed = helpers.messageRange(message);
+      expect(parsed).toBe(null);
+    });
+
+    it('handles invalid v1/diagnostics-store messages', () => {
+      const message = {};
+      const parsed = helpers.messageRange(message);
+      expect(parsed).toBe(null);
+    });
+  });
+
+  describe('messageSeverity', () => {
+    describe('and v1 and diagnostics-store messages', () => {
+      it('correctly pulls the severity out', () => {
+        const message = { type: 'error' };
+        const parsed = helpers.messageSeverity(message);
+        expect(parsed).toBe(message.type);
+      });
+
+      it('handles all cases', () => {
+        const message = { type: 'Error' };
+        const parsed = helpers.messageSeverity(message);
+        expect(parsed).toBe(message.type.toLowerCase());
+      });
+
+      it("changes Types that don't map to severities to 'error'", () => {
+        const message = { type: 'foobar' };
+        const parsed = helpers.messageSeverity(message);
+        expect(parsed).toBe('error');
+      });
+
+      it('handles invalid messages', () => {
+        const message = {};
+        const parsed = helpers.messageSeverity(message);
+        expect(parsed).toBe('error');
+      });
+    });
+
+    describe('and v2 messages', () => {
+      it('correctly pulls the severity out', () => {
+        const message = { severity: 'error' };
+        const parsed = helpers.messageSeverity(message);
+        expect(parsed).toBe(message.severity);
+      });
+
+      it('handles invalid messages', () => {
+        const message = {};
+        const parsed = helpers.messageSeverity(message);
+        expect(parsed).toBe('error');
+      });
+    });
+  });
+
+  describe('goodMessage', () => {
+    it('returns false for messages with no path', () => {
+      const message = {};
+      const isGood = helpers.goodMessage(message, 'foobar');
+      expect(isGood).toBe(false);
+    });
+
+    it('returns false for messages with no range', () => {
+      const filePath = 'foobar';
+      const message = { filePath };
+      const isGood = helpers.goodMessage(message, filePath);
+      expect(isGood).toBe(false);
+    });
+
+    it('returns false for messages with the wrong path', () => {
+      const message = { filePath: 'barfoo', range: [[0, 0], [0, 1]] };
+      const isGood = helpers.goodMessage(message, 'foobar');
+      expect(isGood).toBe(false);
+    });
+
+    it('returns false for messages with the right path but no range', () => {
+      const filePath = 'foobar';
+      const message = { filePath };
+      const isGood = helpers.goodMessage(message, filePath);
+      expect(isGood).toBe(false);
+    });
+
+    it('returns true for messages with the right path and a range', () => {
+      const filePath = 'foobar';
+      const message = { filePath, range: [[0, 0], [0, 1]] };
+      const isGood = helpers.goodMessage(message, filePath);
+      expect(isGood).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Move all of the message handling functions to a helper file, and enhance the tests to be more rigorous and find more faulty messages. Also adds specs for these functions so we don't get regressions.

Fixes #25.