### PR TITLE
Update message format for atom-ide-ui@0.5.2

### DIFF
--- a/lib/minimap-linter.js
+++ b/lib/minimap-linter.js
@@ -120,12 +120,8 @@ export default {
         }
 
         // Filter the message list for the current binding's TextEditor
-        const filteredMessages = messages.filter((message) => {
-          if (message.scope !== 'file' || message.filePath == null) {
-            return false;
-          }
-          return goodMessage(message, filePath);
-        });
+        const filteredMessages = messages.filter(message =>
+          goodMessage(message, filePath));
 
         // Remove any messages not in the given list
         binding.getMessages().forEach((message) => {


### PR DESCRIPTION
The structure of the messages was updated in `atom-ide-ui@0.5.2` to no longer include the `scope` attribute. As it wasn't really being used here in the first place since the file check should fail other messages anyway, simply remove that part of the check.

Fixes #29.