### PR TITLE
test: load and activate test linter more flexibly

### DIFF
--- a/spec/atom-minimap-linter-spec.js
+++ b/spec/atom-minimap-linter-spec.js
@@ -16,11 +16,11 @@ describe('MinimapLinterBinding', () => {
     workspaceElement = atom.views.getView(atom.workspace);
     jasmine.attachToDOM(workspaceElement);
 
-    // Load the fake linter. Note: Non-public API!
-    atom.packages.loadPackage(fakeLinter);
-    // Activate Linter and the fake linter provider
+    // Activate Linter
     await atom.packages.activatePackage('linter');
-    await atom.packages.activatePackage('linter-minimaptest');
+    // Load and activate the fake linter.
+    // NOTE: Somewhat Non-public API, as this isn't _supposed_ to take a path!
+    await atom.packages.activatePackage(fakeLinter);
 
     // Open an editor on the test file
     const editor = await atom.workspace.open(testPath);


### PR DESCRIPTION
The previous method depended on the name of the loaded package to be known, moving to this way of loading and activating the package works on the stable and beta versions of Atom.