### PR TITLE
build: move to a pre-built Atom image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,51 @@
 version: 2
 
 defaults: &defaults
- working_directory: /tmp/project
- docker:
-   - image: circleci/node:latest
-     environment:
-       CIRCLE_BUILD_IMAGE: ubuntu
-       ATOM_CHANNEL: stable
-       APM_TEST_PACKAGES: "minimap linter linter-ui-default busy-signal intentions"
-       DISPLAY: :99
+  working_directory: /tmp/project
+  environment:
+    APM_TEST_PACKAGES: "minimap linter linter-ui-default busy-signal intentions"
+  docker:
+    - image: arcanemagus/atom-docker-ci:stable
+  steps:
+    # Restore project state
+    - attach_workspace:
+        at: /tmp
+    - run:
+        name: Create VFB for Atom to run in
+        command: /usr/local/bin/xvfb_start
+    - run:
+        name: Atom version
+        command: ${ATOM_SCRIPT_PATH} --version
+    - run:
+        name: APM version
+        command: ${APM_SCRIPT_PATH} --version
+    - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
+    - run:
+        name: Package dependencies
+        command: |
+          if [ -n "${APM_TEST_PACKAGES}" ]; then
+            for pack in ${APM_TEST_PACKAGES}; do
+            ${APM_SCRIPT_PATH} install "${pack}"
+            done
+          fi;
+    - run:
+        name: Package specs
+        command: ${ATOM_SCRIPT_PATH} --test spec
+    # Cache node_modules
+    - save_cache:
+        paths:
+          - node_modules
+        key: v2-dependencies-{{ checksum "package.json" }}
 
 jobs:
   checkout_code:
     <<: *defaults
+    docker:
+      - image: circleci/node:latest
     steps:
       - checkout
-      - run:
-          name: Download Atom test script
-          command: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-      - run:
-          name: Make Atom script executable
-          command: chmod u+x build-package.sh
       # Restore node_modules from the last build
       - restore_cache:
           keys:
@@ -33,66 +58,44 @@ jobs:
           root: /tmp
           paths:
             - project
-
+  lint:
+    <<: *defaults
+    docker:
+      - image: circleci/node:latest
+    steps:
+      # Restore project state
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Node.js Version
+          command: node --version
+      - run:
+          name: NPM Version
+          command: npm --version
+      - run:
+          name: Install any remaining dependencies
+          command: npm install
+      - run:
+          name: Lint code
+          command: npm run lint
   stable:
     <<: *defaults
-    steps:
-      # Restore project state
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Update APT
-          command: sudo apt-get update
-      # Install some pre-requisite packages and missing dependencies from the atom package
-      - run:
-          name: Atom Prerequisites
-          command: sudo apt-get --assume-yes --quiet --no-install-suggests --no-install-recommends install sudo xvfb libxss1 libasound2
-      # Fire up a VFB to run Atom in
-      - run:
-          name: Create VFB for Atom to run in
-          command: /usr/bin/Xvfb $DISPLAY -ac -screen 0 1280x1024x16
-          background: true
-      - run:
-          name: Atom test
-          command: ./build-package.sh
-      # Cache node_modules
-      - save_cache:
-          paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
-
   beta:
     <<: *defaults
-    environment:
-      ATOM_CHANNEL: beta
-    steps:
-      # Restore project state
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Update APT
-          command: sudo apt-get update
-      # Install some pre-requisite packages and missing dependencies from the atom package
-      - run:
-          name: Atom Prerequisites
-          command: sudo apt-get --assume-yes --quiet --no-install-suggests --no-install-recommends install sudo xvfb libxss1 libasound2
-      # Fire up a VFB to run Atom in
-      - run:
-          name: Create VFB for Atom to run in
-          command: /usr/bin/Xvfb $DISPLAY -ac -screen 0 1280x1024x16
-          background: true
-      - run:
-          name: Atom test
-          command: ./build-package.sh
+    docker:
+      - image: arcanemagus/atom-docker-ci:beta
 
 workflows:
   version: 2
   test_package:
     jobs:
       - checkout_code
+      - lint:
+          requires:
+            - checkout_code
       - stable:
           requires:
-            - checkout_code
+            - lint
       - beta:
           requires:
-            - checkout_code
+            - lint


### PR DESCRIPTION
Move the Docker image used to an image that has Atom installed already for us. Since the `atom/ci` `build_package.sh` is currently written assuming it must install Atom, we have to move away from it for now.

Splits linting out into a separate job, since Atom bundles a rather old version of Node.js with APM I installed Node.js separately in this job in order to run the linting through.