### PR TITLE
FEATURE: Allow severity-based marker setting

### DIFF
--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -14,25 +14,22 @@ export default class MinimapLinterBinding {
     this.markers = new Map();
     this.decorations = new Set();
     this.idleCallbacks = new Set();
+    this.markerType = {
+      // default value, to be overridden by config
+      error: 'line',
+      warning: 'line',
+      info: 'line',
+    };
 
     this.subscriptions.add(atom.config.observe('minimap-linter.markerTypeError', (value) => {
-      if (!this.markerType) {
-        this.markerType = {};
-      }
       this.markerType.error = value;
       this.removeDecorations();
       this.markers.forEach(this.decorateMarker);
     }), atom.config.observe('minimap-linter.markerTypeWarning', (value) => {
-      if (!this.markerType) {
-        this.markerType = {};
-      }
       this.markerType.warning = value;
       this.removeDecorations();
       this.markers.forEach(this.decorateMarker);
     }), atom.config.observe('minimap-linter.markerTypeInfo', (value) => {
-      if (!this.markerType) {
-        this.markerType = {};
-      }
       this.markerType.info = value;
       this.removeDecorations();
       this.markers.forEach(this.decorateMarker);

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -20,6 +20,14 @@ export default class MinimapLinterBinding {
       warning: 'line',
       info: 'line',
     };
+    // Try to migrate old config if exist
+    let oldMarkerType = atom.config.get('minimap-linter.markerType');
+    if (oldMarkerType) {
+      atom.config.set('minimap-linter.markerTypeError', oldMarkerType);
+      atom.config.set('minimap-linter.markerTypeWarning', oldMarkerType);
+      atom.config.set('minimap-linter.markerTypeInfo', oldMarkerType);
+      atom.config.unset('minimap-linter.markerType');
+    }
 
     this.subscriptions.add(atom.config.observe('minimap-linter.markerTypeError', (value) => {
       this.markerType.error = value;

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -15,10 +15,27 @@ export default class MinimapLinterBinding {
     this.decorations = new Set();
     this.idleCallbacks = new Set();
 
-    this.subscriptions.add(atom.config.observe('minimap-linter.markerType', (value) => {
-      this.markerType = value;
+    this.subscriptions.add(atom.config.observe('minimap-linter.markerTypeError', (value) => {
+      if (!this.markerType) {
+        this.markerType = {};
+      }
+      this.markerType.error = value;
       this.removeDecorations();
-      this.markers.forEach((marker, message) => this.decorateMarker(marker, message));
+      this.markers.forEach(this.decorateMarker);
+    }), atom.config.observe('minimap-linter.markerTypeWarning', (value) => {
+      if (!this.markerType) {
+        this.markerType = {};
+      }
+      this.markerType.warning = value;
+      this.removeDecorations();
+      this.markers.forEach(this.decorateMarker);
+    }), atom.config.observe('minimap-linter.markerTypeInfo', (value) => {
+      if (!this.markerType) {
+        this.markerType = {};
+      }
+      this.markerType.info = value;
+      this.removeDecorations();
+      this.markers.forEach(this.decorateMarker);
     }));
   }
 
@@ -57,12 +74,14 @@ export default class MinimapLinterBinding {
 
   decorateMarker(marker, message) {
     const severity = messageSeverity(message);
-    const minimapMarkerDecoration = this.minimap.decorateMarker(marker, {
-      type: this.markerType,
-      class: `.linter-${severity}`,
-      plugin: 'linter',
-    });
-    this.decorations.add(minimapMarkerDecoration);
+    if (this.markerType[severity] !== 'none') {
+      const minimapMarkerDecoration = this.minimap.decorateMarker(marker, {
+        type: this.markerType[severity],
+        class: `.linter-${severity}`,
+        plugin: 'linter',
+      });
+      this.decorations.add(minimapMarkerDecoration);
+    }
   }
 
   removeDecorations() {

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -21,7 +21,7 @@ export default class MinimapLinterBinding {
       info: 'line',
     };
     // Try to migrate old config if exist
-    let oldMarkerType = atom.config.get('minimap-linter.markerType');
+    const oldMarkerType = atom.config.get('minimap-linter.markerType');
     if (oldMarkerType) {
       atom.config.set('minimap-linter.markerTypeError', oldMarkerType);
       atom.config.set('minimap-linter.markerTypeWarning', oldMarkerType);

--- a/lib/minimap-linter-binding.js
+++ b/lib/minimap-linter-binding.js
@@ -74,7 +74,7 @@ export default class MinimapLinterBinding {
 
   decorateMarker(marker, message) {
     const severity = messageSeverity(message);
-    if (this.markerType[severity] !== 'none') {
+    if (this.markerType[severity] !== 'off') {
       const minimapMarkerDecoration = this.minimap.decorateMarker(marker, {
         type: this.markerType[severity],
         class: `.linter-${severity}`,

--- a/package.json
+++ b/package.json
@@ -23,37 +23,40 @@
       "type": "string",
       "default": "line",
       "enum": [
+        "off",
         "line",
         "gutter",
         "highlight-under",
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for severity:Error highlights"
+      "description": "Marker type for \severity:Error`` highlights"
     },
     "markerTypeWarning": {
       "type": "string",
       "default": "line",
       "enum": [
+        "off",
         "line",
         "gutter",
         "highlight-under",
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for severity:Warning highlights"
+      "description": "Marker type for \severity:Warning`` highlights"
     },
     "markerTypeInfo": {
       "type": "string",
       "default": "gutter",
       "enum": [
+        "off",
         "line",
         "gutter",
         "highlight-under",
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for severity:Info highlights"
+      "description": "Marker type for \severity:Info`` highlights"
     }
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "apm test"
   },
   "configSchema": {
-    "markerType": {
+    "markerTypeError": {
       "type": "string",
       "default": "line",
       "enum": [
@@ -29,7 +29,31 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for linter highlights"
+      "description": "Marker type for severity:Error highlights"
+    },
+    "markerTypeWarning": {
+      "type": "string",
+      "default": "line",
+      "enum": [
+        "line",
+        "gutter",
+        "highlight-under",
+        "highlight-over",
+        "highlight-outline"
+      ],
+      "description": "Marker type for severity:Warning highlights"
+    },
+    "markerTypeInfo": {
+      "type": "string",
+      "default": "gutter",
+      "enum": [
+        "line",
+        "gutter",
+        "highlight-under",
+        "highlight-over",
+        "highlight-outline"
+      ],
+      "description": "Marker type for severity:Info highlights"
     }
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for \severity:Error`` highlights"
+      "description": "Marker type for `severity:Error` highlights"
     },
     "markerTypeWarning": {
       "type": "string",
@@ -43,7 +43,7 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for \severity:Warning`` highlights"
+      "description": "Marker type for `severity:Warning` highlights"
     },
     "markerTypeInfo": {
       "type": "string",
@@ -56,7 +56,7 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for \severity:Info`` highlights"
+      "description": "Marker type for `severity:Info` highlights"
     }
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for `severity:Error` highlights"
+      "description": "Marker type for error highlights"
     },
     "markerTypeWarning": {
       "type": "string",
@@ -43,11 +43,11 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for `severity:Warning` highlights"
+      "description": "Marker type for warning highlights"
     },
     "markerTypeInfo": {
       "type": "string",
-      "default": "gutter",
+      "default": "line",
       "enum": [
         "off",
         "line",
@@ -56,7 +56,7 @@
         "highlight-over",
         "highlight-outline"
       ],
-      "description": "Marker type for `severity:Info` highlights"
+      "description": "Marker type for info highlights"
     }
   },
   "consumedServices": {


### PR DESCRIPTION
This feature will provide more fine-grained control over the marker style by the level of severity, in addition to a new 'off' marker type which disables marker rendering for that severity completely.

Use case: one may want to display errors as a whole red line, warnings as a small gutter, and no info on the minimap.
![image](https://user-images.githubusercontent.com/8077540/45471077-8f150e80-b762-11e8-8011-c364666db82e.png)

Close #21.