### PR TITLE
Adds activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
       }
     }
   },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ],
   "package-deps": [
     "linter:2.1.1"
   ],

--- a/spec/atom-minimap-linter-spec.js
+++ b/spec/atom-minimap-linter-spec.js
@@ -16,6 +16,10 @@ describe('MinimapLinterBinding', () => {
     workspaceElement = atom.views.getView(atom.workspace);
     jasmine.attachToDOM(workspaceElement);
 
+    // Activate activation hook
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+
     // Activate Linter
     await atom.packages.activatePackage('linter');
     // Load and activate the fake linter.


### PR DESCRIPTION
This speeds up loading of Atom, by deferring the loading of minimap-linter until the core Atom shell is loaded. Most apparent when you have an editor open from the previous session.