### PR TITLE
fix: add minimap-plus to package-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,14 @@
     }
   },
   "package-deps": [
-    {
-      "name": "minimap"
-    },
+    [
+      {
+        "name": "minimap-plus"
+      },
+      {
+        "name": "minimap"
+      }
+    ],
     {
       "name": "linter",
       "minimumVersion": "2.1.1"


### PR DESCRIPTION
This added minimap-plus to package-deps. Minimap-plus is the updated version of minimap developed at @atom-ide-community 